### PR TITLE
Migrate to wrangler-action for deployments

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -33,12 +33,13 @@ jobs:
 
     - name: Publish to Cloudflare Pages
       id: deploy
-      uses: cloudflare/pages-action@v1
+      uses: cloudflare/wrangler-action@v3
       if: ${{ github.actor != 'dependabot[bot]' }}
       with:
         apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         accountId: ${{secrets.CLOUDFLARE_ACCOUNT_ID }}
-        projectName: zwift-ical
-        directory: public
         gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-        branch: main
+        command: |
+          pages deploy public/ --project-name=zwift-ical --branch=main
+        
+


### PR DESCRIPTION
## Summary by Sourcery

Migrate GitHub workflow to use cloudflare/wrangler-action@v3 for Pages deployments

CI:
- Replace cloudflare/pages-action@v1 with cloudflare/wrangler-action@v3
- Consolidate projectName, directory, and branch parameters into a single 'pages deploy' command